### PR TITLE
Fix plotClonalFrequency on genome and region plots

### DIFF
--- a/R/plotting.R
+++ b/R/plotting.R
@@ -1,4 +1,4 @@
-# author: Gavin Ha 
+# author: Gavin Ha
 # 		  Dana-Farber Cancer Institute
 #		  Broad Institute
 # contact: <gavinha@gmail.com> or <gavinha@broadinstitute.org>
@@ -8,18 +8,18 @@
 # F} alphaVal = [0,1] geneAnnot is a dataframe with
 # 4 columns: geneSymbol, chr, start, stop spacing
 # is the distance between each track
-plotAllelicRatio <- function(dataIn, chr = NULL, geneAnnot = NULL, 
+plotAllelicRatio <- function(dataIn, chr = NULL, geneAnnot = NULL,
     spacing = 4,  xlim = NULL, ...) {
     # color coding alphaVal <- ceiling(alphaVal * 255);
     # class(alphaVal) = 'hexmode'
-    lohCol <- c("#00FF00", "#006400", "#0000FF", "#8B0000", 
-        "#006400", "#BEBEBE", "#FF0000", "#BEBEBE", 
+    lohCol <- c("#00FF00", "#006400", "#0000FF", "#8B0000",
+        "#006400", "#BEBEBE", "#FF0000", "#BEBEBE",
         "#FF0000")
     # lohCol <- paste(lohCol,alphaVal,sep='') lohCol <-
     # col2rgb(c('green','darkgreen','blue','darkgreen','grey','red'))
-    names(lohCol) <- c("HOMD", "DLOH", "NLOH", "GAIN", 
+    names(lohCol) <- c("HOMD", "DLOH", "NLOH", "GAIN",
         "ALOH", "HET", "ASCNA", "BCNA", "UBCNA")
-    
+
     dataIn <- copy(dataIn)
     if (!is.null(chr)) {
         for (i in chr) {
@@ -32,33 +32,33 @@ plotAllelicRatio <- function(dataIn, chr = NULL, geneAnnot = NULL,
             if (missing(xlim)) {
                 xlim <- as.numeric(c(1, dataByChr[nrow(dataByChr), Position]))
             }
-            plot(dataByChr[, Position], dataByChr[, 
-                AllelicRatio], col = lohCol[dataByChr[, 
-                TITANcall]], pch = 16, xaxt = "n", 
-                las = 1, ylab = "Allelic Ratio", xlim = xlim, 
+            plot(dataByChr[, Position], dataByChr[,
+                AllelicRatio], col = lohCol[dataByChr[,
+                TITANcall]], pch = 16, xaxt = "n",
+                las = 1, ylab = "Allelic Ratio", xlim = xlim,
                 ...)
-            lines(as.numeric(c(1, dataByChr[nrow(dataByChr), 
-                Position])), rep(0.5, 2), type = "l", 
+            lines(as.numeric(c(1, dataByChr[nrow(dataByChr),
+                Position])), rep(0.5, 2), type = "l",
                 col = "grey", lwd = 3)
-            
+
             if (!is.null(geneAnnot)) {
                 plotGeneAnnotation(geneAnnot, i)
             }
         }
     } else {
         # plot for all chromosomes
-        coord <- getGenomeWidePositions(dataIn[, Chr], 
+        coord <- getGenomeWidePositions(dataIn[, Chr],
             dataIn[, Position])
-        plot(coord$posns, as.numeric(dataIn[, AllelicRatio]), 
-            col = lohCol[dataIn[, TITANcall]], pch = 16, 
-            xaxt = "n", bty = "n", las = 1, ylab = "Allelic Fraction", 
+        plot(coord$posns, as.numeric(dataIn[, AllelicRatio]),
+            col = lohCol[dataIn[, TITANcall]], pch = 16,
+            xaxt = "n", bty = "n", las = 1, ylab = "Allelic Fraction",
             ...)
-        lines(as.numeric(c(1, coord$posns[length(coord$posns)])), 
-            rep(0.5, 2), type = "l", col = "grey", 
+        lines(as.numeric(c(1, coord$posns[length(coord$posns)])),
+            rep(0.5, 2), type = "l", col = "grey",
             lwd = 3)
-        plotChrLines(unique(dataIn[, Chr]), coord$chrBkpt, 
+        plotChrLines(unique(dataIn[, Chr]), coord$chrBkpt,
             c(-0.1, 1.1))
-        
+
     }
 }
 
@@ -66,15 +66,15 @@ plotAllelicRatio <- function(dataIn, chr = NULL, geneAnnot = NULL,
 # [0,1] geneAnnot is a dataframe with 4 columns:
 # geneSymbol, chr, start, stop spacing is the
 # distance between each track
-plotClonalFrequency <- function(dataIn, chr = NULL, 
+plotClonalFrequency <- function(dataIn, chr = NULL,
     normal = NULL, geneAnnot = NULL, spacing = 4, xlim = NULL, ...) {
     # color coding
-    lohCol <- c("#00FF00", "#006400", "#0000FF", "#8B0000", 
-        "#006400", "#BEBEBE", "#FF0000", "#FF0000", 
+    lohCol <- c("#00FF00", "#006400", "#0000FF", "#8B0000",
+        "#006400", "#BEBEBE", "#FF0000", "#FF0000",
         "#FF0000")
-    names(lohCol) <- c("HOMD", "DLOH", "NLOH", "GAIN", 
+    names(lohCol) <- c("HOMD", "DLOH", "NLOH", "GAIN",
         "ALOH", "HET", "ASCNA", "BCNA", "UBCNA")
-    
+
     # get unique set of cluster and estimates table:
     # 1st column is cluster number, 2nd column is
     # clonal freq
@@ -85,7 +85,7 @@ plotClonalFrequency <- function(dataIn, chr = NULL,
     }
     dataToUse <- copy(dataIn)
     dataToUse <- dataToUse[TITANcall != "OUT", ]
-    #dataToUse[CellularPrevalence == "NA" | is.na(CellularPrevalence), 
+    #dataToUse[CellularPrevalence == "NA" | is.na(CellularPrevalence),
     #          list(ClonalCluster, CellularPrevalence) := c(NA, NA)]
     # extract clonal info
     clonalFreq <- dataToUse[, list(ClonalCluster, CellularPrevalence)]
@@ -93,9 +93,9 @@ plotClonalFrequency <- function(dataIn, chr = NULL,
     if (!is.null(normal)) {
         clonalFreq[, CellularPrevalence := CellularPrevalence * (1 - normal)]
     }
-    clonalFreq[is.na(CellularPrevalence) | CellularPrevalence == "0" | 
+    clonalFreq[is.na(CellularPrevalence) | CellularPrevalence == "0" |
                  CellularPrevalence == "NA", CellularPrevalence := 0]
-    
+
     # plot per chromosome
     if (!is.null(chr)) {
         for (i in chr) {
@@ -105,83 +105,87 @@ plotClonalFrequency <- function(dataIn, chr = NULL,
             # plot the data
             par(mar = c(spacing, 8, 2, 2), xpd = NA)
             # par(xpd=NA)
-            
+
             # PLOT CLONAL FREQUENCIES
             if (missing(xlim)) {
                 xlim <- as.numeric(c(1, dataByChr[nrow(dataByChr), Position]))
             }
-            plot(dataByChr[, Position], clonalFreq[, CellularPrevalence], type = "h", 
-                 col = lohCol[dataByChr[, TITANcall]], las = 1, xaxt = "n", 
+            plot(dataByChr[, Position], clonalFreq[, CellularPrevalence], type = "h",
+                 col = lohCol[dataByChr[, TITANcall]], las = 1, xaxt = "n",
                 ylab = "Cellular Prevalence", xlim = xlim, ...)
-            
+
             # plot cluster lines and labels
             if (nrow(clusters) > 0){
-				for (j in 1:length(clusters[, 1])) {
-					chrLen <- as.numeric(dataByChr[dim(dataByChr)[1], Position])
-					lines(c(1 - chrLen * 0.02, chrLen * 1.02), 
-					      rep(clusters[j, 2], 2), type = "l", col = "grey", lwd = 3)
-					mtext(side = 4, at = clusters[j, 2], 
-					  text = paste("Z", clusters[j, 1], "", sep = ""), 
-					  cex = 1, padj = 0.5, adj = 1, las = 2, outer = FALSE)
-					mtext(side = 2, at = clusters[j, 2], 
-					      text = paste("Z", clusters[j, 1], "", sep = ""), 
-					      cex = 1, padj = 0.5, 
-					  adj = 0, las = 2, outer = FALSE)
-				}
-			}
-            
+                for (row in 1:nrow(clusters)) {
+                    prevalence <- clusters[row, CellularPrevalence]
+                    clustnum <- clusters[row, ClonalCluster]
+                    chrLen <- as.numeric(dataByChr[dim(dataByChr)[1], Position])
+                    lines(c(1 - chrLen * 0.02, chrLen * 1.02),
+                          rep(prevalence , 2), type = "l", col = "grey", lwd = 3)
+                    mtext(side = 4, at = prevalence,
+                          text = paste("Z", clustnum, "", sep = ""),
+                          cex = 1, padj = 0.5, adj = 1, las = 2, outer = FALSE)
+                    mtext(side = 2, at = prevalence,
+                          text = paste("Z", clustnum, "", sep = ""),
+                          cex = 1, padj = 0.5,
+                          adj = 0, las = 2, outer = FALSE)
+                }
+            }
+
             if (!is.null(normal)) {
                 chrLen <- as.numeric(dataByChr[nrow(dataByChr), Position])
-                lines(c(1 - chrLen * 0.02, chrLen * 
-                  1.02), rep((1 - normal), 2), type = "l", 
+                lines(c(1 - chrLen * 0.02, chrLen *
+                  1.02), rep((1 - normal), 2), type = "l",
                   col = "#000000", lwd = 3)
-                #mtext(side = 4, at = (1 - normal), 
-                  #text = paste("-T-", sep = ""), padj = 0.5, 
+                #mtext(side = 4, at = (1 - normal),
+                  #text = paste("-T-", sep = ""), padj = 0.5,
                   #adj = 1, cex = 1, las = 2, outer = FALSE)
-                #mtext(side = 2, at = (1 - normal), 
-                  #text = paste("-T-", sep = ""), padj = 0.5, 
+                #mtext(side = 2, at = (1 - normal),
+                  #text = paste("-T-", sep = ""), padj = 0.5,
                   #adj = 0, cex = 1, las = 2, outer = FALSE)
             }
-            
+
             if (!is.null(geneAnnot)) {
                 plotGeneAnnotation(geneAnnot, i)
             }
         }
     } else {
         # plot genome-wide
-        coord <- getGenomeWidePositions(dataIn[, Chr], 
+        coord <- getGenomeWidePositions(dataIn[, Chr],
             dataIn[, Position])
-        plot(coord$posns, clonalFreq[, CellularPrevalence], type = "h", 
-            col = lohCol[dataIn[, TITANcall]], pch = 16, 
-            xaxt = "n", las = 1, bty = "n", ylab = "Cellular Prevalence", 
+        plot(coord$posns, clonalFreq[, CellularPrevalence], type = "h",
+            col = lohCol[dataIn[, TITANcall]], pch = 16,
+            xaxt = "n", las = 1, bty = "n", ylab = "Cellular Prevalence",
             ...)
-        plotChrLines(unique(dataIn[, Chr]), coord$chrBkpt, 
+        plotChrLines(unique(dataIn[, Chr]), coord$chrBkpt,
             c(-0.1, 1.1))
-        
+
         # plot cluster lines and labels
       	if (nrow(clusters) > 0){
-					for (j in 1:length(clusters[, 1])) {
-							chrLen <- as.numeric(coord$posns[length(coord$posns)])
-							lines(c(1 - chrLen * 0.02, chrLen * 1.02), 
-									rep(clusters[j, 2], 2), type = "l", 
-									col = "grey", lwd = 3)
-							mtext(side = 4, at = clusters[j, 2], text = paste("Z", 
-									clusters[j, 1], "", sep = ""), cex = 1, 
-									padj = 0.5, adj = 1, las = 2, outer = FALSE)
-							mtext(side = 2, at = clusters[j, 2], text = paste("Z", 
-									clusters[j, 1], "", sep = ""), cex = 1, 
-									padj = 0.5, adj = 0, las = 2, outer = FALSE)
-					}
+             for (row in 1:nrow(clusters)) {
+                prevalence <- clusters[row, CellularPrevalence]
+                clustnum <- clusters[row, ClonalCluster]
+                chrLen <- as.numeric(coord$posns[length(coord$posns)])
+                lines(c(1 - chrLen * 0.02, chrLen * 1.02),
+                      rep(prevalence, 2), type = "l",
+                      col = "grey", lwd = 3)
+                mtext(side = 4, at = prevalence, text = paste("Z",
+                      clustnum, "", sep = ""), cex = 1,
+                      padj = 0.5, adj = 1, las = 2, outer = FALSE)
+                mtext(side = 2, at = prevalence, text = paste("Z",
+                      clustnum, "", sep = ""), cex = 1,
+                      padj = 0.5, adj = 0, las = 2, outer = FALSE)
+            }
         }
         if (!is.null(normal)) {
             chrLen <- as.numeric(coord$posns[length(coord$posns)])
-            lines(c(1 - chrLen * 0.02, chrLen * 1.02), 
-                rep((1 - normal), 2), type = "l", col = "#000000", 
+            lines(c(1 - chrLen * 0.02, chrLen * 1.02),
+                rep((1 - normal), 2), type = "l", col = "#000000",
                 lwd = 3)
         }
-        
+
     }
-    
+
 }
 
 
@@ -190,18 +194,18 @@ plotClonalFrequency <- function(dataIn, chr = NULL,
 # alphaVal = [0,1] geneAnnot is a dataframe with 4
 # columns: geneSymbol, chr, start, stop spacing is
 # the distance between each track
-plotCNlogRByChr <- function(dataIn, chr = NULL, segs = NULL, geneAnnot = NULL, 
+plotCNlogRByChr <- function(dataIn, chr = NULL, segs = NULL, geneAnnot = NULL,
     ploidy = NULL, normal = NULL, spacing = 4, alphaVal = 1, xlim = NULL, ...) {
     # color coding
     alphaVal <- ceiling(alphaVal * 255)
     class(alphaVal) = "hexmode"
-    cnCol <- c("#00FF00", "#006400", "#0000FF", "#880000", 
+    cnCol <- c("#00FF00", "#006400", "#0000FF", "#880000",
         "#BB0000", "#CC0000", "#DD0000", "#EE0000", "#FF0000")
     cnCol <- paste(cnCol, alphaVal, sep = "")
     # cnCol <-
     # col2rgb(c('green','darkgreen','blue','darkred','red','brightred'))
     names(cnCol) <- c("0", "1", "2", "3", "4", "5", "6", "7", "8")
-    
+
     dataIn <- copy(dataIn)
     ## adjust logR values for ploidy ##
     if (!is.null(ploidy)) {
@@ -209,7 +213,7 @@ plotCNlogRByChr <- function(dataIn, chr = NULL, segs = NULL, geneAnnot = NULL,
     		stop("plotCNlogRByChr: Please provide \"normal\" contamination estimate.")
     	}
         dataIn[, LogRatio := LogRatio + log2(((1-normal)*ploidy+normal*2)/2)]
-        
+
       if (!is.null(segs)){
         segs.sample <- copy(segs)
 				segs.sample[, Median_logR := Median_logR + log2(((1-normal)*ploidy+normal*2) / 2)]
@@ -228,19 +232,19 @@ plotCNlogRByChr <- function(dataIn, chr = NULL, segs = NULL, geneAnnot = NULL,
                 xlim <- as.numeric(c(1, dataByChr[nrow(dataByChr), Position]))
             }
             coord <- as.numeric(dataByChr[, Position])
-            plot(coord, as.numeric(dataByChr[, LogRatio]), 
-                col = cnCol[as.character(dataByChr[, CopyNumber])], pch = 16, xaxt = "n", 
+            plot(coord, as.numeric(dataByChr[, LogRatio]),
+                col = cnCol[as.character(dataByChr[, CopyNumber])], pch = 16, xaxt = "n",
                 las = 1, ylab = "Copy Number (log ratio)", xlim = xlim, ...)
             lines(xlim, rep(0, 2), type = "l", col = "grey", lwd = 0.75)
             if (!is.null(segs)){
 							segsByChr <- segs.sample[Chromosome == as.character(i), ]
 							tmp <- apply(segsByChr, 1, function(x){
-								lines(x[c("Start_Position.bp.","End_Position.bp.")], 
+								lines(x[c("Start_Position.bp.","End_Position.bp.")],
 										rep(x["Median_logR"], 2), col = "green", lwd = 3, lend = 1)
 							})
 						}
-  
-            
+
+
             if (!is.null(geneAnnot)) {
                 plotGeneAnnotation(geneAnnot, i)
             }
@@ -248,11 +252,11 @@ plotCNlogRByChr <- function(dataIn, chr = NULL, segs = NULL, geneAnnot = NULL,
     } else {
         # plot for all chromosomes
         coord <- getGenomeWidePositions(dataIn[, Chr], dataIn[, Position])
-        plot(coord$posns, as.numeric(dataIn[, LogRatio]), 
-            col = cnCol[as.character(dataIn[, CopyNumber])], 
-            pch = 16, xaxt = "n", las = 1, bty = "n", 
+        plot(coord$posns, as.numeric(dataIn[, LogRatio]),
+            col = cnCol[as.character(dataIn[, CopyNumber])],
+            pch = 16, xaxt = "n", las = 1, bty = "n",
             ylab = "Copy Number (log ratio)", ...)
-        lines(as.numeric(c(1, coord$posns[length(coord$posns)])), 
+        lines(as.numeric(c(1, coord$posns[length(coord$posns)])),
             rep(0, 2), type = "l", col = "grey", lwd = 2)
         plotChrLines(dataIn[, Chr], coord$chrBkpt, par("yaxp")[1:2])
         #plot segments
@@ -270,18 +274,18 @@ plotCNlogRByChr <- function(dataIn, chr = NULL, segs = NULL, geneAnnot = NULL,
 				}
 
     }
-    
+
 }
 
 plotSubcloneProfiles <- function(dataIn, chr = NULL, geneAnnot = NULL,
 	spacing = 4, xlim = NULL, ...){
 	args <- list(...)
-	lohCol <- c("#00FF00", "#006400", "#0000FF", "#8B0000", 
-        "#006400", "#BEBEBE", "#FF0000", "#FF0000", 
+	lohCol <- c("#00FF00", "#006400", "#0000FF", "#8B0000",
+        "#006400", "#BEBEBE", "#FF0000", "#FF0000",
         "#FF0000")
-    names(lohCol) <- c("HOMD", "DLOH", "NLOH", "GAIN", 
+    names(lohCol) <- c("HOMD", "DLOH", "NLOH", "GAIN",
         "ALOH", "HET", "ASCNA", "BCNA", "UBCNA")
-        
+
     ## pull out params from dots ##
     if (!is.null(args$cex.axis)) cex.axis <- args$cex.axis else cex.axis <- 0.75
     if (!is.null(args$cex.lab)) cex.lab <- args$cex.lab else cex.lab <- 0.75
@@ -293,20 +297,20 @@ plotSubcloneProfiles <- function(dataIn, chr = NULL, geneAnnot = NULL,
         for (i in chr) {
             ind <- dataIn[, Chr == as.character(i)]
             dataByChr <- dataIn[ind, ]
-            
+
             ## find x domain #
             if (missing(xlim)) {
     			xlim <- c(1, dataByChr[.N, Position])
     		}
-            
+
             # plot the data
             par(mar = c(spacing, 8, 2, 2), xpd = NA)
-          
+
             # PLOT SUBCLONE PROFILES
             # setup plot to include X number of clones (numClones)
             maxCN <- dataByChr[, max(CopyNumber)] + 1
             ylim <- c(0, numClones * (maxCN + 2) - 1)
-            plot(0, type = "n", xaxt = "n", ylab = "", xlab = "", 
+            plot(0, type = "n", xaxt = "n", ylab = "", xlab = "",
             	xlim = xlim, ylim = ylim, yaxt = "n", ...)
             axis(2, at = seq(ylim[1], ylim[2], 1), las = 1,
             	labels = rep(c(0:maxCN, "---"), numClones), cex.axis=cex.axis)
@@ -322,15 +326,15 @@ plotSubcloneProfiles <- function(dataIn, chr = NULL, geneAnnot = NULL,
             	call <- dataByChr[, get(paste0("Subclone", i, ".TITANcall"))]
             	points(dataByChr[, Position], val, col = lohCol[call], pch = 15, ...)
             	#lines(dataIn[, Position], val, col = lohCol[call], type = "l", lwd = 3, ...)
-               	mtext(text = paste0("Subclone", i, "\n", format(cellPrev, digits = 2)), 
-               		side = 2, las = 0, line = 3, 
+               	mtext(text = paste0("Subclone", i, "\n", format(cellPrev, digits = 2)),
+               		side = 2, las = 0, line = 3,
                		at = i * (maxCN + 2) - (maxCN + 2) / 2 - 1, cex = cex.lab)
                	chrLen <- as.numeric(dataByChr[.N, Position])
-                lines(c(1 - chrLen * 0.035, chrLen * 
-                  1.035), rep(i * (maxCN + 2) - 1, 2), type = "l", 
+                lines(c(1 - chrLen * 0.035, chrLen *
+                  1.035), rep(i * (maxCN + 2) - 1, 2), type = "l",
                   col = "black", lwd = 1.5)
             }
-            
+
             if (!is.null(geneAnnot)) {
                 plotGeneAnnotation(geneAnnot, i)
             }
@@ -342,7 +346,7 @@ plotSubcloneProfiles <- function(dataIn, chr = NULL, geneAnnot = NULL,
 		maxCN <- dataIn[, max(CopyNumber)] + 1
 		ylim <- c(0, numClones * (maxCN + 2) - 1)
 		xlim <- as.numeric(c(1, coord$posns[length(coord$posns)]))
-		plot(0, type = "n", xaxt = "n", bty = "n", ylab = "", xlim = xlim, 
+		plot(0, type = "n", xaxt = "n", bty = "n", ylab = "", xlim = xlim,
 			ylim = ylim, yaxt = "n", ...)
 		axis(2, at = seq(ylim[1], ylim[2], 1), las = 1,
 			labels = rep(c(0:maxCN, "---"), numClones))
@@ -354,27 +358,27 @@ plotSubcloneProfiles <- function(dataIn, chr = NULL, geneAnnot = NULL,
 			}
 			call <- dataIn[, get(paste0("Subclone", i, ".TITANcall"))]
 			points(coord$posns, val, col = lohCol[call], pch = 15, ...)
-			mtext(text = paste0("Subclone", i), side = 2, las = 0, 
+			mtext(text = paste0("Subclone", i), side = 2, las = 0,
 					line = 2, at = i * (maxCN + 2) - (maxCN + 2) / 2 - 1, cex = 0.75)
 				chrLen <- xlim[2]
-			lines(c(1 - chrLen * 0.035, chrLen * 
-			  1.035), rep(i * (maxCN + 2) - 1, 2), type = "l", 
+			lines(c(1 - chrLen * 0.035, chrLen *
+			  1.035), rep(i * (maxCN + 2) - 1, 2), type = "l",
 			  col = "black", lwd = 1.5)
 		}
         plotChrLines(unique(dataIn[, Chr]), coord$chrBkpt, ylim)
     }
-    
+
 }
 
 ## TODO: Not completed ##
-plotAllelicCN <- function(dataIn, resultType = "AllelicRatio", 
-                          chr = NULL, geneAnnot = NULL, 
+plotAllelicCN <- function(dataIn, resultType = "AllelicRatio",
+                          chr = NULL, geneAnnot = NULL,
     ploidy = 2, spacing = 4, alphaVal = 1, xlim = NULL, ...) {
     # color coding
     alphaVal <- ceiling(alphaVal * 255)
     class(alphaVal) = "hexmode"
-    cnCol <- c("#00FF00", "#006400", "#0000FF", "#880000", 
-        "#BB0000", "#CC0000", "#DD0000", "#EE0000", 
+    cnCol <- c("#00FF00", "#006400", "#0000FF", "#880000",
+        "#BB0000", "#CC0000", "#DD0000", "#EE0000",
         "#FF0000")
     cnCol <- paste(cnCol, alphaVal, sep = "")
     # cnCol <-
@@ -384,7 +388,7 @@ plotAllelicCN <- function(dataIn, resultType = "AllelicRatio",
     ## compute allelic copy number for each
     dataIn[, Allele.1 := get(resultType) * 2^LogRatio*ploidy]
     dataIn[, Allele.2 := (1 - get(resultType)) * 2^LogRatio*ploidy]
-   
+
     if (!is.null(chr)) {
         for (i in chr) {
             dataByChr <- dataIn[Chr == i, ]
@@ -395,15 +399,15 @@ plotAllelicCN <- function(dataIn, resultType = "AllelicRatio",
                 xlim <- as.numeric(c(1, dataByChr[.N, Position]))
             }
             coord <- dataByChr[, Position]
-            plot(coord, dataByChr[, Allele.1], 
-                col = cnCol[as.character(dataByChr[, CopyNumber])], pch = 16, 
-                xaxt = "n", las = 1, ylab = "Copy Number", 
+            plot(coord, dataByChr[, Allele.1],
+                col = cnCol[as.character(dataByChr[, CopyNumber])], pch = 16,
+                xaxt = "n", las = 1, ylab = "Copy Number",
                 xlim = xlim, ...)
             points(coord, dataByChr[, Allele.2],
-                   col = cnCol[as.character(dataByChr[, CopyNumber])], 
+                   col = cnCol[as.character(dataByChr[, CopyNumber])],
                    pch = 16)
             lines(xlim, rep(0, 2), type = "l", col = "grey", lwd = 0.75)
-            
+
             if (!is.null(geneAnnot)) {
                 plotGeneAnnotation(geneAnnot, i)
             }
@@ -413,9 +417,9 @@ plotAllelicCN <- function(dataIn, resultType = "AllelicRatio",
 
 
 
-plotSegmentMedians <- function(dataIn, resultType = "LogRatio", 
-                               plotType = "CopyNumber", chr = NULL, 
-		geneAnnot = NULL, ploidy = NULL, spacing = 4, alphaVal = 1, xlim = NULL, 
+plotSegmentMedians <- function(dataIn, resultType = "LogRatio",
+                               plotType = "CopyNumber", chr = NULL,
+		geneAnnot = NULL, ploidy = NULL, spacing = 4, alphaVal = 1, xlim = NULL,
 		plot.new = FALSE, lwd = 8, ...){
 
 	## check for the possible resultType to plot ##
@@ -433,25 +437,25 @@ plotSegmentMedians <- function(dataIn, resultType = "LogRatio",
 	names(axisNameCN) <- c("LogRatio", "AllelicRatio")
 	colName <- c("Copy_Number","TITAN_call", "TITAN_call")
 	names(colName) <- c("LogRatio", "AllelicRatio", "HaplotypeRatio")
-	
+
 	dataIn <- copy(dataIn)
 	# color coding
     alphaVal <- ceiling(alphaVal * 255)
     class(alphaVal) = "hexmode"
-    
+
     if (resultType == "LogRatio"){
-		cnCol <- c("#00FF00", "#006400", "#0000FF", "#880000", 
+		cnCol <- c("#00FF00", "#006400", "#0000FF", "#880000",
 			"#BB0000", "#CC0000", "#DD0000", "#EE0000", "#FF0000")
 		cnCol <- paste(cnCol, alphaVal, sep = "")
 		# cnCol <-
 		# col2rgb(c('green','darkgreen','blue','darkred','red','brightred'))
 		names(cnCol) <- c("0", "1", "2", "3", "4", "5", "6", "7", "8")
 	}else if (resultType %in% c("AllelicRatio", "HaplotypeRatio")){
-		cnCol <- c("#00FF00", "#006400", "#0000FF", "#8B0000", 
+		cnCol <- c("#00FF00", "#006400", "#0000FF", "#8B0000",
         	"#006400", "#BEBEBE", "#FF0000", "#BEBEBE", "#FF0000")
     # lohCol <- paste(lohCol,alphaVal,sep='') lohCol <-
     # col2rgb(c('green','darkgreen','blue','darkgreen','grey','red'))
-    names(cnCol) <- c("HOMD", "DLOH", "NLOH", "GAIN", 
+    names(cnCol) <- c("HOMD", "DLOH", "NLOH", "GAIN",
         "ALOH", "HET", "ASCNA", "BCNA", "UBCNA")
 	}
     if (plotType == "CopyNumber"){
@@ -474,13 +478,13 @@ plotSegmentMedians <- function(dataIn, resultType = "LogRatio",
       #dataIn[, Allele.1 := get(dataType[resultType]) * 2 ^ Median_logR * ploidy]
       #dataIn[, Allele.2 := (1 - get(dataType[resultType])) * 2 ^ Median_logR * ploidy]
     }
-    
+
     # plot for specified chromosomes #
 	if (!is.null(chr)) {
     	for (i in chr) {
     		dataByChr <- dataIn[Chromosome == i, ]
         dataByChr <- dataByChr[TITAN_call != "OUT", ]
-        # plot the data 
+        # plot the data
         par(mar = c(spacing, 8, 2, 2))
         if (missing(xlim)) {
             xlim <- as.numeric(c(1, dataByChr[.N, End_Position.bp.]))
@@ -498,7 +502,7 @@ plotSegmentMedians <- function(dataIn, resultType = "LogRatio",
           value <- dataByChr[, get(dataType[resultType])]
         }
         if (plot.new){
-        	plot(0, type = "n", col = col, xaxt = "n", las = 1, 
+        	plot(0, type = "n", col = col, xaxt = "n", las = 1,
         		ylab = axisName[resultType], xlim = xlim, ...)
         }
         tmp <- apply(cbind(coord, value, col), 1, function(x){
@@ -517,7 +521,7 @@ plotSegmentMedians <- function(dataIn, resultType = "LogRatio",
         }
     	}
     } else {
-        # plot for all chromosomes        
+        # plot for all chromosomes
         coordEnd <- getGenomeWidePositions(dataIn[, Chromosome], dataIn[, End_Position.bp.])
     	  coordStart <- coordEnd$posns - (dataIn[, End_Position.bp.] - dataIn[, Start_Position.bp.] + 1)
         xlim <- as.numeric(c(1, coordEnd$posns[length(coordEnd$posns)]))
@@ -530,12 +534,12 @@ plotSegmentMedians <- function(dataIn, resultType = "LogRatio",
             value <- dataIn[, Copy_Number]
           }
     	  }else{
-          value <- dataIn[, get(dataType[resultType])]  
+          value <- dataIn[, get(dataType[resultType])]
         }
         #mat <- data.table(cbind(coordStart, coordEnd$posns, value, col))
         #rownames(mat) <- 1:nrow(mat)
         if (plot.new){
-        	plot(0, type = "n", col = col, xaxt = "n", las = 1, 
+        	plot(0, type = "n", col = col, xaxt = "n", las = 1,
            		ylab = axisName[resultType], xlim = xlim, ...)
         }
         tmp <- apply(data.table(coordStart, coordEnd$posns, value, col), 1, function(x){
@@ -554,24 +558,24 @@ plotSegmentMedians <- function(dataIn, resultType = "LogRatio",
 }
 
 plotGeneAnnotation <- function(geneAnnot, chr = 1, ...) {
-    colnames(geneAnnot) <- c("Gene", "Chr", "Start", 
+    colnames(geneAnnot) <- c("Gene", "Chr", "Start",
         "Stop")
-    geneAnnot <- geneAnnot[geneAnnot[, "Chr"] == as.character(chr), 
+    geneAnnot <- geneAnnot[geneAnnot[, "Chr"] == as.character(chr),
         ]
     if (nrow(geneAnnot) != 0) {
         for (g in 1:dim(geneAnnot)[1]) {
             # print(geneAnnot[g,'Gene'])
-            abline(v = as.numeric(geneAnnot[g, "Start"]), 
+            abline(v = as.numeric(geneAnnot[g, "Start"]),
                 col = "black", lty = 3, xpd = FALSE)
-            abline(v = as.numeric(geneAnnot[g, "Stop"]), 
+            abline(v = as.numeric(geneAnnot[g, "Stop"]),
                 col = "black", lty = 3, xpd = FALSE)
-            atP <- (as.numeric(geneAnnot[g, "Stop"]) - 
-                as.numeric(geneAnnot[g, "Start"]))/2 + 
+            atP <- (as.numeric(geneAnnot[g, "Stop"]) -
+                as.numeric(geneAnnot[g, "Start"]))/2 +
                 as.numeric(geneAnnot[g, "Start"])
             # if (atP < dataByChr[1,2]){ atP <- dataByChr[1,2]
             # }else if (atP > dataByChr[dim(dataByChr)[1],2]){
             # atP <- dataByChr[dim(dataByChr)[1],2] }
-            mtext(geneAnnot[g, "Gene"], side = 3, line = 0, 
+            mtext(geneAnnot[g, "Gene"], side = 3, line = 0,
                 at = atP, ...)
         }
     }
@@ -580,7 +584,7 @@ plotGeneAnnotation <- function(geneAnnot, chr = 1, ...) {
 plotChrLines <- function(chrs, chrBkpt, yrange) {
     # plot vertical chromosome lines
     for (j in 1:length(chrBkpt)) {
-        lines(rep(chrBkpt[j], 2), yrange, type = "l", 
+        lines(rep(chrBkpt[j], 2), yrange, type = "l",
             lty = 2, col = "black", lwd = 0.75)
     }
     numLines <- length(chrBkpt)
@@ -590,7 +594,7 @@ plotChrLines <- function(chrs, chrBkpt, yrange) {
     chrsToShow <- sort(unique(as.numeric(chrs)))
     chrsToShow[chrsToShow == 23] <- "X"
     chrsToShow[chrsToShow == 24] <- "Y"
-    axis(side = 1, at = mid, labels = c(chrsToShow), 
+    axis(side = 1, at = mid, labels = c(chrsToShow),
         cex.axis = 1.5, tick = FALSE)
 }
 
@@ -607,4 +611,4 @@ getGenomeWidePositions <- function(chrs, posns) {
     }
     chrBkpt[i + 1] <- positions[length(positions)]
     return(list(posns = positions, chrBkpt = chrBkpt))
-} 
+}


### PR DESCRIPTION
As told in issue #12:

 In the code for the function, clusters expands to

```r
> clusters
   ClonalCluster CellularPrevalence
1:             2          0.7714099
2:             3          0.6370672
3:             1          1.0000000
4:             4          0.5077241
```

When plotting, the code does

```r
if (nrow(clusters) > 0) {
            for (j in 1:length(clusters[, 1])) {
```

However:

```r
> 1:length(clusters[, 1])
[1] 1
```

This PR fixes it by iterating on the actual data.table instead of using
`length()`. Notice that the diff may show a much larger change than
expected because I also fixed part of the indentation.

This fixes issue #12.