### PR TITLE
Sychronize to `.params.txt` for run scripts

### DIFF
--- a/scripts/R_scripts/titanCNA.R
+++ b/scripts/R_scripts/titanCNA.R
@@ -161,7 +161,7 @@ if (is.null(outfile)){
 	outfile <- paste0(outdir, "/", id, "_cluster", numClustersStr, ".titan.txt")
 }
 if (is.null(outparam)){
-	outparam <- gsub(".titan.txt", ".param.txt", outfile)
+	outparam <- gsub(".titan.txt", ".params.txt", outfile)
 }
 if (is.null(outseg)){
 	outseg <- gsub(".titan.txt", ".segs.txt", outfile)

--- a/scripts/TenX_scripts/titanCNA_v1.15.0_TenX.R
+++ b/scripts/TenX_scripts/titanCNA_v1.15.0_TenX.R
@@ -125,7 +125,7 @@ if (is.null(outfile)){
 	outfile <- paste0(outdir, "/", id, "_cluster", numClustersStr, ".titan.txt")
 }
 if (is.null(outparam)){
-	outparam <- gsub(".titan.txt", ".param.txt", outfile)
+	outparam <- gsub(".titan.txt", ".params.txt", outfile)
 }
 if (is.null(outseg)){
 	outseg <- gsub(".titan.txt", ".segs.txt", outfile)


### PR DESCRIPTION
Gavin;
While integrating TitanCNA into bcbio, I ran into the issue Luca reported with the mismatch between file ending defaults when not using snakemake. This is a small patch to consistently use a single naming convention throughout. Thanks much for all the help so far, we're making good progress on having TitanCNA fully integrated.

`selectSolutions.R` expects parameter scripts to end with `.params.txt`
which is the default in the snakemake scripts but not the base
`titanCNA.R` script which uses `.param.txt`. This swaps over to use
`params.txt` consistently throughout. Fixes gavinha/TitanCNA#7