### PR TITLE
Plotting fix for multiple arguments

### DIFF
--- a/scripts/R_scripts/titanCNA.R
+++ b/scripts/R_scripts/titanCNA.R
@@ -385,7 +385,7 @@ if (as.numeric(numClusters) <= 2){
 	#png(outFile,width=1000,height=300)
 	pdf(outFile,width=20,height=6)
 	plotSubcloneProfiles(dataIn=results, chr=chrs, cex = 0.5, spacing=4,
-                             main=id, cex.axis=1.5, xlab="")
+                             main=id, cex.axis=1.5)
 	dev.off()
 }
 


### PR DESCRIPTION
Fixes an error with xlab getting passed twice in plotSubcloneProfiles
through the extra keyword argument:
```
Error in plot.default(0, type = "n", xaxt = "n", ylab = "", xlab = "", :
  formal argument "xlab" matched by multiple actual arguments
    Calls: plotSubcloneProfiles -> plot -> plot
```