### PR TITLE
hg38 plots: data frame fix for cytoband

### DIFF
--- a/scripts/R_scripts/titanCNA.R
+++ b/scripts/R_scripts/titanCNA.R
@@ -294,6 +294,7 @@ if (genomeBuild == "hg38" && file.exists(cytobandFile)){
 	names(cytoband) <- c("chrom", "start", "end", "name", "gieStain")
 	cytoband <- cytoband[chrom %in% chrs]
 	cytoband$chrom <- setGenomeStyle(cytoband$chrom, genomeStyle = genomeStyle)
+	cytoband <- as.data.frame(cytoband)
 }
 for (chr in unique(results$Chr)){
 	chrStr <- chr


### PR DESCRIPTION
The fixes for genes and cytoband chromosome naming (https://github.com/gavinha/TitanCNA/commit/8fb529d6b9e19084a756da3917243ed6b53c13c6)
changed the conversion of the cytoband object into a data frame, which
causes plotIdiogram.hg38 to be unhappy:
```
Error in ESC[38;5;5m[.data.tableESC[0m(cytoband, cytoband[, "chrom"] == chromosome, ) :
  i is invalid type (matrix). Perhaps in future a 2 column matrix could return a list of elements of DT (in the spirit of A[B] in FAQ 2.14). Please report to data.table issue tracker if you'd like this, or add your comments to FR #657.
Calls: plotIdiogram.hg38 -> [ -> [.data.table
```
This adds the conversion back in after the chromosome handling.