### PR TITLE
Check for NAs during parameter estimation

### DIFF
--- a/R/paramEstimation.R
+++ b/R/paramEstimation.R
@@ -256,14 +256,15 @@ updateParameters <- function(n_0, s_0, var_0, varR_0, phi_0, corRho_0, chrPos_0,
         var_prev <- var
         varR_prev <- varR
         phi_prev <- phi
-        
-        if (objfun[maxFind] >= objfun[i]) {
+
+	if (is.na(objfun[maxFind]) || is.na(objfun[i])) {
+        } else if (objfun[maxFind] >= objfun[i]) {
           #if (verbose)
             #message("Coordinate descent decreases likelihood.")
-        } else {
+	} else {
             maxFind <- i
         }
-        if ((abs(objfun[i] - objfun[i - 1])/abs(objfun[i])) <= 0.001) {
+	if (!is.na(objfun[i]) && (abs(objfun[i] - objfun[i - 1])/abs(objfun[i])) <= 0.001) {
             converged <- 1
         }
     }


### PR DESCRIPTION
Avoids errors when running copy number estimation:
```
titan: Parameter estimation
Optimal state path computation: Using 8 cores.
Error in if (objfun[maxFind] >= objfun[i]) { :
  missing value where TRUE/FALSE needed
Calls: outputTitanResults ... runEMclonalCN -> estimateClonalCNParamsMap -> updateParameters
```
I couldn't determine the underlying source of NAs when reading the code but
put in defensive checks which avoids the issue.