### PR TITLE
Adding a small script in the snakemake scripts to parse a standard data csv into the samples.yaml format required by the snakemake pipeline

### DIFF
--- a/scripts/snakemake/code/writeSampleYaml
+++ b/scripts/snakemake/code/writeSampleYaml
@@ -1,0 +1,48 @@
+import pandas as pd
+import yaml
+import argparse
+import os
+
+#sample_name,normal_name,tumor_bam,normal_bam
+#sample_T1D_E,sample_N1D_E,/data/path/sample_T1D_E.bwa.final.bam,/data/path/sample_N1D_E.bwa.final.bam
+
+def main():
+
+    parser = argparse.ArgumentParser(
+    description='Write a samples.yaml file in the input asked by the TitanCNA snakemake pipeline from a standard csv file containing columns of tumor sample name, tumor bam file location, normal bam name, and normal bam file location. csv should be in wide format with each row having a tumor-normal pair. Give the column numbers for the appropriate cols.',
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument('--sampleCSV', dest='sampleCSV', action='append', required=True,
+        help='Path to csv file containing sample information, should have header')
+    parser.add_argument('--tnc', dest='tumorNameCol', action='append', required=True,
+        help='The column index with the names of the tumor samples')
+    parser.add_argument('--tbc', dest='tumorBamCol', action='append', required=False,
+        help='The column index with the filepaths of the tumor sample bams')
+    parser.add_argument('--nnc', dest='normalNameCol', action='append', required=False,
+        help='The column index with the names of the tumor sample bams')
+    parser.add_argument('--nbc', dest='normalBamCol', action='append', required=False,
+        help='File path to PhyloWGS output *.mutass.zip file')
+    parser.add_argument('--r', dest='resultsFile', default = "samples.yaml", required=False,
+        help='File path for output - default is current working directory samples.yaml')
+
+
+    args = parser.parse_args()
+    #read in the sample csv file with pandas
+    data = pd.read_csv(args.sampleCSV[0])
+
+
+    #tumor samples
+
+    sample_bam = pd.Series(data.iloc[:,int(args.tumorBamCol[0])].values,index=data.iloc[:,int(args.tumorNameCol[0])]).to_dict()
+    #update with the normal samples
+    sample_bam.update(pd.Series(data.iloc[:,int(args.normalBamCol[0])].values,index=data.iloc[:,int(args.normalNameCol[0])]).to_dict())
+    #grab the normals and the samples and zip them into a pretty list
+    tumor_pairings = pd.Series(data.iloc[:,int(args.normalNameCol[0])].values,index=data.iloc[:,int(args.tumorNameCol[0])]).to_dict() 
+
+    print(args.resultsFile)
+    with open(args.resultsFile, 'w') as outfile:
+        yaml.dump({"samples": sample_bam,"pairings": tumor_pairings}, outfile, default_flow_style=False)
+
+
+if __name__ == '__main__':
+  main()

--- a/scripts/snakemake/code/writeSampleYaml.py
+++ b/scripts/snakemake/code/writeSampleYaml.py
@@ -2,7 +2,7 @@ import pandas as pd
 import yaml
 import argparse
 import os
-
+#parses a standard wide form csv
 #sample_name,normal_name,tumor_bam,normal_bam
 #sample_T1D_E,sample_N1D_E,/data/path/sample_T1D_E.bwa.final.bam,/data/path/sample_N1D_E.bwa.final.bam
 
@@ -21,7 +21,7 @@ def main():
     parser.add_argument('--nnc', dest='normalNameCol', action='append', required=False,
         help='The column index with the names of the tumor sample bams')
     parser.add_argument('--nbc', dest='normalBamCol', action='append', required=False,
-        help='File path to PhyloWGS output *.mutass.zip file')
+        help='The column index with the filepaths of the tumor sample bames')
     parser.add_argument('--r', dest='resultsFile', default = "samples.yaml", required=False,
         help='File path for output - default is current working directory samples.yaml')
 


### PR DESCRIPTION
Wrote this for myself since I'm not storing my data in the format asked by the snakemake pipeline, maybe something like this would be useful to others. and it was faster to write this than rewrite the way the snakemake pipeline took in data. 