### PR TITLE
fix the default path in config.yaml for titan script

### DIFF
--- a/scripts/snakemake/config/config.yaml
+++ b/scripts/snakemake/config/config.yaml
@@ -8,7 +8,7 @@ ichorCNA_libdir:  /path/to/ichorCNA_code
 pyCountScript:  code/countPysam.py
 TitanCNA_rscript: ../R_scripts/titanCNA.R
 TitanCNA_selectSolutionRscript: ../R_scripts/selectSolution.R
-TitanCNA_libdir:  ../../R/
+TitanCNA_libdir:  ../../
 
 ## reference settings and paths to reference files ##
 genomeBuild: hg19


### PR DESCRIPTION
https://github.com/Olimon660/TitanCNA/blob/master/scripts/R_scripts/titanCNA.R#L111

in titanCNA.R it looks for paste0(libdir, "**/R**/plotting.R")
removing the extra /R/ here to avoid confusion.