### PR TITLE
Add SNPchip as a dependency.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -6,10 +6,10 @@ Version: 1.23.1
 Date: 2019-05-24
 Author: Gavin Ha
 Maintainer: Gavin Ha <gha@fredhutch.org>
-Depends: R (>= 3.5.1)
+Depends: R (>= 3.5.1), SNPchip
 Imports: IRanges (>= 2.6.1), GenomicRanges (>= 1.24.3), VariantAnnotation (>= 1.18.7),
         foreach (>= 1.4.3), GenomeInfoDb (>= 1.8.7), 
-        data.table (>= 1.10.4), dplyr (>= 0.5.0), 
+        data.table (>= 1.10.4), dplyr (>= 0.5.0)
 Description: Hidden Markov model to segment and predict regions of
         subclonal copy number alterations (CNA) and loss of
         heterozygosity (LOH), and estimate cellular prevalence of


### PR DESCRIPTION
Luca brought this up here bcbio/bcbio-nextgen#2874, the dependency is checked for [here](https://github.com/gavinha/TitanCNA/blob/9c45b4eb9e2e3a5cfd1e1be245b767186d6972d3/scripts/R_scripts/titanCNA.R#L29), but isn't included in the DESCRIPTION as a dependency. This adds it.

Thanks!

If this pull request is mangled, forgive me, trying out [hub](https://hub.github.com) for the first time. :)